### PR TITLE
fix modile bug when open auth modal

### DIFF
--- a/src/components/UI/AuthIcon/LoginIcon.tsx
+++ b/src/components/UI/AuthIcon/LoginIcon.tsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react'
 import { useAuthStore } from '@/store/authStore'
 import { useStoreData } from '@/hooks/useStoreData'
 import { usePathname } from 'next/navigation'
+import { pagePaths } from '@/constants/pagePaths'
 
 export default function LoginIcon() {
   const pathname = usePathname()
@@ -24,8 +25,8 @@ export default function LoginIcon() {
   )
 
   useEffect(() => {
-    // Close the modal window when navigating to the profile page because the open state remains true until the page is refreshed
-    if (pathname === '/profile' || pathname === '/') {
+    // Close the modal window when navigating to a page specified in pagePaths
+    if (pagePaths[pathname]) {
       resetOpenModal()
     }
   }, [pathname, resetOpenModal])

--- a/src/constants/pagePaths.ts
+++ b/src/constants/pagePaths.ts
@@ -1,0 +1,11 @@
+type PagePaths = {
+  [key: string]: boolean
+}
+
+export const pagePaths: PagePaths = {
+  '/': true,
+  '/profile': true,
+  '/favourites': true,
+  '/cart': true,
+  // Add any other paths and their corresponding conditions here
+}


### PR DESCRIPTION
now on a mobile device when the authorization modal window is open, you can click on links in the header