### PR TITLE
Trim allowed Google redirect origins from env

### DIFF
--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const ALLOWED_REDIRECT_ORIGINS = (process.env.ALLOWED_REDIRECT_ORIGINS ?? '').split(',').filter(Boolean)
+const ALLOWED_REDIRECT_ORIGINS = (process.env.ALLOWED_REDIRECT_ORIGINS ?? '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean)
 
 export async function GET(request: NextRequest) {
   const redirectUrl = request.nextUrl.searchParams.get('redirectUrl') ?? ''


### PR DESCRIPTION
This hardens Google OAuth redirect origin parsing in the frontend route.

What changed:
- keep reading `ALLOWED_REDIRECT_ORIGINS` from the environment
- trim whitespace around comma-separated values before matching

Why:
- Vercel env values are often entered as comma-separated lists
- if a space is added after a comma, exact origin matching can fail and return HTTP 400 before the backend is reached

Example supported value:
`ALLOWED_REDIRECT_ORIGINS=https://iced-latte.uk, https://www.iced-latte.uk`
