### PR TITLE
Fix guest favourites sync dedupe after auth

### DIFF
--- a/__tests__/unit/favorites/store.test.ts
+++ b/__tests__/unit/favorites/store.test.ts
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom'
+import { useFavouritesStore } from '../../../src/features/favorites/store'
+import { getProductByIds } from '../../../src/features/products/api'
+import { mergeFavs } from '../../../src/features/favorites/api'
+import type { IProduct } from '../../../src/features/products/types'
+
+jest.mock('../../../src/features/products/api', () => ({
+  getProductByIds: jest.fn(),
+}))
+
+jest.mock('../../../src/features/favorites/api', () => ({
+  mergeFavs: jest.fn(),
+  removeFavItem: jest.fn(),
+  getFavByIds: jest.fn(),
+}))
+
+const mockedGetProductByIds = jest.mocked(getProductByIds)
+const mockedMergeFavs = jest.mocked(mergeFavs)
+
+const product: IProduct = {
+  id: 'product-1',
+  name: 'Test Coffee',
+  description: 'Test description',
+  price: 9.99,
+  quantity: 10,
+  active: true,
+  productFileUrl: null,
+  averageRating: 5,
+  reviewsCount: 3,
+  brandName: 'Test Brand',
+  sellerName: 'Test Seller',
+}
+
+describe('favourites store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    jest.clearAllMocks()
+    useFavouritesStore.setState({
+      favouriteIds: [],
+      favourites: [],
+      count: 0,
+      loading: false,
+      isSync: false,
+    })
+  })
+
+  it('deduplicates guest favourites before updating local state', async () => {
+    mockedGetProductByIds.mockResolvedValue([product])
+
+    await useFavouritesStore.getState().addFavourite(product.id, null)
+    await useFavouritesStore.getState().addFavourite(product.id, null)
+
+    expect(mockedGetProductByIds).toHaveBeenLastCalledWith([product.id])
+    expect(useFavouritesStore.getState().favouriteIds).toEqual([product.id])
+    expect(useFavouritesStore.getState().count).toBe(1)
+  })
+
+  it('normalizes duplicated ids after backend sync', async () => {
+    mockedMergeFavs.mockResolvedValue({ products: [product] })
+
+    useFavouritesStore.setState({
+      favouriteIds: [product.id, product.id],
+      favourites: [],
+      count: 2,
+      loading: false,
+      isSync: false,
+    })
+
+    await useFavouritesStore.getState().syncBackendFav()
+
+    expect(mockedMergeFavs).toHaveBeenCalledWith({ productIds: [product.id] })
+    expect(useFavouritesStore.getState().favouriteIds).toEqual([product.id])
+    expect(useFavouritesStore.getState().count).toBe(1)
+  })
+})

--- a/__tests__/unit/favorites/store.test.ts
+++ b/__tests__/unit/favorites/store.test.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 import { useFavouritesStore } from '../../../src/features/favorites/store'
 import { getProductByIds } from '../../../src/features/products/api'
-import { mergeFavs } from '../../../src/features/favorites/api'
+import { mergeFavs, removeFavItem } from '../../../src/features/favorites/api'
 import type { IProduct } from '../../../src/features/products/types'
 
 jest.mock('../../../src/features/products/api', () => ({
@@ -16,6 +16,7 @@ jest.mock('../../../src/features/favorites/api', () => ({
 
 const mockedGetProductByIds = jest.mocked(getProductByIds)
 const mockedMergeFavs = jest.mocked(mergeFavs)
+const mockedRemoveFavItem = jest.mocked(removeFavItem)
 
 const product: IProduct = {
   id: 'product-1',
@@ -53,6 +54,51 @@ describe('favourites store', () => {
     expect(mockedGetProductByIds).toHaveBeenLastCalledWith([product.id])
     expect(useFavouritesStore.getState().favouriteIds).toEqual([product.id])
     expect(useFavouritesStore.getState().count).toBe(1)
+  })
+
+  it('normalizes authenticated favourites after a successful merge', async () => {
+    mockedMergeFavs.mockResolvedValue({ products: [product] })
+
+    useFavouritesStore.setState({
+      favouriteIds: [product.id],
+      favourites: [],
+      count: 1,
+      loading: false,
+      isSync: false,
+    })
+
+    await useFavouritesStore.getState().addFavourite(product.id, 'token')
+
+    expect(mockedMergeFavs).toHaveBeenCalledWith({ productIds: [product.id] })
+    expect(useFavouritesStore.getState().favouriteIds).toEqual([product.id])
+    expect(useFavouritesStore.getState().count).toBe(1)
+  })
+
+  it('rolls back favourite ids when authenticated merge fails', async () => {
+    mockedMergeFavs.mockRejectedValue(new Error('merge failed'))
+
+    await useFavouritesStore.getState().addFavourite(product.id, 'token')
+
+    expect(useFavouritesStore.getState().favouriteIds).toEqual([])
+    expect(useFavouritesStore.getState().count).toBe(0)
+  })
+
+  it('updates the count when a favourite is removed', async () => {
+    mockedRemoveFavItem.mockResolvedValue({ products: [] })
+
+    useFavouritesStore.setState({
+      favouriteIds: [product.id],
+      favourites: [product],
+      count: 1,
+      loading: false,
+      isSync: false,
+    })
+
+    await useFavouritesStore.getState().removeFavourite(product.id, 'token')
+
+    expect(mockedRemoveFavItem).toHaveBeenCalledWith(product.id)
+    expect(useFavouritesStore.getState().favouriteIds).toEqual([])
+    expect(useFavouritesStore.getState().count).toBe(0)
   })
 
   it('normalizes duplicated ids after backend sync', async () => {

--- a/src/features/favorites/store.ts
+++ b/src/features/favorites/store.ts
@@ -32,36 +32,48 @@ const initialState: FavSliceState = {
   isSync: false,
 }
 
+const getUniqueFavouriteIds = (productIds: string[]): string[] => Array.from(new Set(productIds))
+
 export const useFavouritesStore = create<FavStoreState>()(
   persist(
     (set, get) => ({
       ...initialState,
       setLoading: (loading) => set({ loading }),
       addFavourite: async (id, token) => {
-        const updatedIds = [...get().favouriteIds, id]
+        const updatedIds = getUniqueFavouriteIds([...get().favouriteIds, id])
 
-        set({ favouriteIds: updatedIds })
+        set({ favouriteIds: updatedIds, count: updatedIds.length })
         if (token) {
           try {
             const reqItems: IFavPushItems = { productIds: updatedIds }
             const response = await mergeFavs(reqItems)
             const ids = response.products.map((p) => p.id)
 
-            set({ favourites: response.products, favouriteIds: ids })
+            set({ favourites: response.products, favouriteIds: ids, count: ids.length })
           } catch {
-            set((state) => ({ favouriteIds: state.favouriteIds.filter((fid) => fid !== id) }))
+            set((state) => {
+              const fallbackIds = state.favouriteIds.filter((fid) => fid !== id)
+
+              return { favouriteIds: fallbackIds, count: fallbackIds.length }
+            })
           }
         } else {
           const products = await getProductByIds(updatedIds)
 
-          set({ favourites: products })
+          set({ favourites: products, count: updatedIds.length })
         }
       },
       removeFavourite: async (id, token) => {
-        set((state) => ({
-          favouriteIds: state.favouriteIds.filter((favId) => favId !== id),
-          favourites: state.favourites.filter((fav) => fav.id !== id),
-        }))
+        set((state) => {
+          const favouriteIds = state.favouriteIds.filter((favId) => favId !== id)
+          const favourites = state.favourites.filter((fav) => fav.id !== id)
+
+          return {
+            favouriteIds,
+            favourites,
+            count: favouriteIds.length,
+          }
+        })
         if (token) {
           try {
             await removeFavItem(id)
@@ -84,11 +96,11 @@ export const useFavouritesStore = create<FavStoreState>()(
       },
       syncBackendFav: async () => {
         const { favouriteIds } = get()
-        const reqItems: IFavPushItems = { productIds: favouriteIds }
+        const reqItems: IFavPushItems = { productIds: getUniqueFavouriteIds(favouriteIds) }
         const response = await mergeFavs(reqItems)
         const ids = response.products.map((p) => p.id)
 
-        set((state) => ({ ...state, favourites: response.products, favouriteIds: ids }))
+        set((state) => ({ ...state, favourites: response.products, favouriteIds: ids, count: ids.length }))
       },
       resetFav: () => set({ favourites: [], favouriteIds: [], count: 0, loading: false }),
     }),


### PR DESCRIPTION
## Summary
- deduplicate guest favourite ids before local and backend sync
- keep the favourites count aligned with the normalized ids
- add unit tests for guest dedupe and post-auth normalization

## Why
A guest user could accumulate duplicate favourite ids locally, then see the state collapse unexpectedly after auth sync when the backend normalized the list.

## Testing
- added Jest store tests for guest duplicate favourites
- added Jest store tests for backend sync normalization