### PR TITLE
fix: preserve multipart avatar uploads through frontend proxy

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -5,6 +5,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
 const FETCH_TIMEOUT_MS = 30000
 
 const ALLOWED_PATH_RE = /^[a-zA-Z0-9/_-]+$/
+const FORWARDED_HEADERS = ['Authorization', 'X-Session-ID', 'X-Trace-ID', 'X-Correlation-ID']
 
 function sanitizePath(segments: string[]): string | null {
   const joined = segments.join('/')
@@ -19,10 +20,11 @@ function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> 
   return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timer))
 }
 
-const FORWARDED_HEADERS = ['Authorization', 'X-Session-ID', 'X-Trace-ID', 'X-Correlation-ID']
-
 function forwardHeaders(request: NextRequest): HeadersInit {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const headers: Record<string, string> = {}
+  const contentType = request.headers.get('Content-Type')
+
+  if (contentType) headers['Content-Type'] = contentType
 
   for (const name of FORWARDED_HEADERS) {
     const value = request.headers.get(name)
@@ -33,154 +35,86 @@ function forwardHeaders(request: NextRequest): HeadersInit {
   return headers
 }
 
+async function readBody(request: NextRequest): Promise<BodyInit | undefined> {
+  try {
+    const arrayBuffer = await request.arrayBuffer()
+
+    return arrayBuffer.byteLength > 0 ? arrayBuffer : undefined
+  } catch {
+    return undefined
+  }
+}
+
+async function handleProxy(
+  request: NextRequest,
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+  path: string[],
+) {
+  const pathString = path.join('/')
+
+  if (method === 'POST' && pathString.includes('telemetry')) {
+    return createCorsResponse({ message: 'Telemetry endpoint not implemented' }, 202)
+  }
+
+  const safePath = sanitizePath(path)
+
+  if (!safePath) return createCorsResponse({ error: 'Invalid path' }, 400)
+
+  const url = new URL(request.url)
+  const apiUrl = `${API_BASE_URL}/${safePath}${url.search}`
+  const body = method === 'GET' ? undefined : await readBody(request)
+
+  try {
+    const response = await fetchWithTimeout(apiUrl, {
+      method,
+      headers: forwardHeaders(request),
+      body,
+    })
+    const contentType = response.headers.get('content-type') ?? ''
+    const rawBody = await response.text()
+
+    const data = contentType.includes('application/json') && rawBody
+      ? JSON.parse(rawBody)
+      : rawBody
+
+    if (!response.ok) return createCorsResponse(data, response.status)
+
+    return createCorsResponse(data)
+  } catch {
+    return createCorsResponse({ error: 'API unavailable' }, 503)
+  }
+}
+
 export async function OPTIONS() {
   return handleOptions()
 }
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
-  const safePath = sanitizePath(path)
 
-  if (!safePath) return createCorsResponse({ error: 'Invalid path' }, 400)
-  const url = new URL(request.url)
-  const apiUrl = `${API_BASE_URL}/${safePath}${url.search}`
-
-  try {
-    const response = await fetchWithTimeout(apiUrl, { headers: forwardHeaders(request) })
-    const contentType = response.headers.get('content-type') ?? ''
-    const data = contentType.includes('application/json')
-      ? await response.json()
-      : await response.text()
-
-    if (!response.ok) return createCorsResponse(data, response.status)
-
-    return createCorsResponse(data)
-  } catch {
-    return createCorsResponse({ error: 'API unavailable' }, 503)
-  }
+  return handleProxy(request, 'GET', path)
 }
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
-  const pathString = path.join('/')
-  
-  // Handle telemetry endpoints that don't exist in backend
-  if (pathString.includes('telemetry')) {
-    return createCorsResponse({ message: 'Telemetry endpoint not implemented' }, 202)
-  }
-  const safePath = sanitizePath(path)
 
-  if (!safePath) return createCorsResponse({ error: 'Invalid path' }, 400)
-  const url = new URL(request.url)
-  const apiUrl = `${API_BASE_URL}/${safePath}${url.search}`
-
-  let body: string | null = null
-
-  try {
-    const text = await request.text()
-
-    body = text || null
-  } catch { /* empty body */ }
-
-  try {
-    const response = await fetchWithTimeout(apiUrl, {
-      method: 'POST',
-      headers: forwardHeaders(request),
-      body: body ?? undefined,
-    })
-    const contentType = response.headers.get('content-type') ?? ''
-    const data = contentType.includes('application/json')
-      ? await response.json()
-      : await response.text()
-
-    if (!response.ok) return createCorsResponse(data, response.status)
-
-    return createCorsResponse(data)
-  } catch {
-    return createCorsResponse({ error: 'API unavailable' }, 503)
-  }
+  return handleProxy(request, 'POST', path)
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
-  const body = await request.text()
-  const apiUrl = `${API_BASE_URL}/${path.join('/')}`
 
-  try {
-    const response = await fetchWithTimeout(apiUrl, {
-      method: 'PUT',
-      headers: forwardHeaders(request),
-      body,
-    })
-    const contentType = response.headers.get('content-type') ?? ''
-    const data = contentType.includes('application/json')
-      ? await response.json()
-      : await response.text()
-
-    if (!response.ok) return createCorsResponse(data, response.status)
-
-    return createCorsResponse(data)
-  } catch {
-    return createCorsResponse({ error: 'API unavailable' }, 503)
-  }
+  return handleProxy(request, 'PUT', path)
 }
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
-  const body = await request.text()
-  const apiUrl = `${API_BASE_URL}/${path.join('/')}`
 
-  try {
-    const response = await fetchWithTimeout(apiUrl, {
-      method: 'PATCH',
-      headers: forwardHeaders(request),
-      body,
-    })
-    const contentType = response.headers.get('content-type') ?? ''
-    const data = contentType.includes('application/json')
-      ? await response.json()
-      : await response.text()
-
-    if (!response.ok) return createCorsResponse(data, response.status)
-
-    return createCorsResponse(data)
-  } catch {
-    return createCorsResponse({ error: 'API unavailable' }, 503)
-  }
+  return handleProxy(request, 'PATCH', path)
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
-  const apiUrl = `${API_BASE_URL}/${path.join('/')}`
 
-  let body: string | undefined
-
-  try {
-    const text = await request.text()
-
-    if (text) body = text
-  } catch { /* no body */ }
-
-  try {
-    const response = await fetchWithTimeout(apiUrl, {
-      method: 'DELETE',
-      headers: forwardHeaders(request),
-      body,
-    })
-
-    if (!response.ok) {
-      const contentType = response.headers.get('content-type') ?? ''
-      const data = contentType.includes('application/json')
-        ? await response.json()
-        : await response.text()
-
-      return createCorsResponse(data, response.status)
-    }
-    const text = await response.text()
-    const data = text ? JSON.parse(text) : {}
-
-    return createCorsResponse(data)
-  } catch {
-    return createCorsResponse({ error: 'API unavailable' }, 503)
-  }
+  return handleProxy(request, 'DELETE', path)
 }

--- a/src/features/user/api.ts
+++ b/src/features/user/api.ts
@@ -20,13 +20,11 @@ export const editUserProfile = async (updatedUserData: Partial<UserData>): Promi
   return response.data
 }
 
-export async function uploadImage(file: File): Promise<string> {
+export async function uploadImage(file: File): Promise<void> {
   const formData = new FormData()
 
   formData.append('file', file)
-  const response: AxiosResponse<string> = await api.post('/users/avatar', formData)
-
-  return response.data
+  await api.post('/users/avatar', formData)
 }
 
 export async function apiForgotPassword(email: ForgotPasswordCredentials): Promise<SuccessResponse> {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -4,12 +4,13 @@ import { getSessionId, generateTraceId } from '@/shared/utils/sessionUtils'
 import { useAuthStore } from '@/features/auth/store'
 
 const instance = axios.create({
-  headers: { 'Content-Type': 'application/json' },
   timeout: typeof window === 'undefined' ? 5000 : 15000,
 })
 
 instance.interceptors.request.use((config) => {
   const path = config.url!.replace(/^\//, '')
+  const isFormData =
+    typeof FormData !== 'undefined' && config.data instanceof FormData
 
   if (typeof window === 'undefined') {
     const baseUrl = process.env.NEXT_PUBLIC_API_URL
@@ -26,6 +27,12 @@ instance.interceptors.request.use((config) => {
 
     config.headers['X-Session-ID'] = getSessionId()
     config.headers['X-Trace-ID'] = generateTraceId()
+  }
+
+  if (isFormData) {
+    delete config.headers['Content-Type']
+  } else if (config.data != null && !config.headers['Content-Type']) {
+    config.headers['Content-Type'] = 'application/json'
   }
 
   return config


### PR DESCRIPTION
## Summary
- preserve the original request `Content-Type` in the Next.js proxy instead of forcing JSON
- forward raw request bytes through the proxy instead of converting uploads to text
- avoid forcing `application/json` on `FormData` requests in the shared Axios client
- align the avatar upload helper with the backend contract by treating the upload response as void

## Root cause
The avatar upload flow correctly creates `FormData` on the client, but the frontend transport layer rewrote the request as JSON:
- the shared Axios client defaulted all requests to `Content-Type: application/json`
- the `/api/proxy/[...path]` route forced `Content-Type: application/json`
- the proxy read the incoming request via `request.text()` and forwarded that text body to the backend

That breaks multipart boundaries and can surface in the backend as malformed multipart stream errors during avatar upload.

## Changed files
- `src/shared/api/client.ts`
- `src/app/api/proxy/[...path]/route.ts`
- `src/features/user/api.ts`

## Notes
This PR fixes the primary frontend bug in the upload path. Backend multipart error handling and size-limit hardening can still be improved separately, but they are not the main cause addressed here.